### PR TITLE
Fix broken public file reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = (nextConfig = {}) => {
             options: {
               limit: 8192,
               fallback: "file-loader",
-              publicPath: "/_next/",
+              publicPath: "/_next/static/fonts/",
               outputPath: "static/fonts/",
               name: "[name]-[hash].[ext]"
             }


### PR DESCRIPTION
Fonts could not be loaded due to a broken public path reference.

I think this should fix it, but I will probably extend Webpack myself now :)