### PR TITLE
Add support for assetPrefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = (nextConfig = {}) => {
         )
       }
 
+      const assetPrefix = nextConfig.assetPrefix || "";
+
       config.module.rules.push({
         test: /\.(woff|woff2|eot|ttf|otf)$/,
         use: [
@@ -15,7 +17,7 @@ module.exports = (nextConfig = {}) => {
             options: {
               limit: 8192,
               fallback: "file-loader",
-              publicPath: "/_next/static/fonts/",
+              publicPath: `${assetPrefix}/_next/static/fonts/`,
               outputPath: "static/fonts/",
               name: "[name]-[hash].[ext]"
             }


### PR DESCRIPTION
Prepends `nextConfig.assetPrefix` to the `publicPath`, if available.
This feature was already added to [arefaslani/next-images](https://github.com/arefaslani/next-images/commit/83940113ee9ab7cfb747ef9b8f41a5611a940a84) and it would be great to see it added here as well.