### PR TITLE
set output path to chunks folder inside static

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = (nextConfig = {}) => {
             options: {
               limit: 8192,
               fallback: 'file-loader',
-              publicPath: `${assetPrefix}/_next/static/fonts/`,
-              outputPath: `${isServer ? "../" : ""}static/fonts/`,
+              publicPath: `${assetPrefix}/_next/static/chunks/fonts/`,
+              outputPath: `${isServer ? "../" : ""}static/chunks/fonts/`,
               name: '[name]-[hash].[ext]'
             }
           }


### PR DESCRIPTION
This avoids an issue where cache-control maxage being set to 0.

Fonts are currently served by Next with the following headers:

```
HTTP/1.1 200 OK
X-Powered-By: Express
Accept-Ranges: bytes
Cache-Control: public, max-age=0
Last-Modified: Tue, 30 Jul 2019 05:41:03 GMT
ETag: W/"7ee0-16c4165726c"
Content-Type: application/font-woff2
Content-Length: 32480
Date: Tue, 30 Jul 2019 05:43:32 GMT
Connection: keep-alive
```

This PR updates the output path to be `static/chunks/fonts` which ensures Next adds the default static asset cache header to the response.

```
HTTP/1.1 200 OK
X-Powered-By: Express
Cache-Control: public, max-age=31536000, immutable
Accept-Ranges: bytes
Last-Modified: Tue, 30 Jul 2019 05:37:37 GMT
ETag: W/"4ae4-16c4162501a"
Content-Type: application/font-woff2
Content-Length: 19172
Date: Tue, 30 Jul 2019 05:40:20 GMT
```

### Further reading
- https://github.com/zeit/next.js/issues/5464
- https://github.com/hydrateio/next-css/commit/f1648ec2748fbcb1e62d6b8f0212e1b97f1ad230