### PR TITLE
Fixes package requires

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,10 @@ module.exports = (nextConfig = {}) => {
         test: testPattern,
         use: [
           {
-            loader: 'url-loader',
+            loader: require.resolve('url-loader'),
             options: {
               limit: 8192,
-              fallback: 'file-loader',
+              fallback: require.resolve('file-loader'),
               publicPath: `${assetPrefix}/_next/static/chunks/fonts/`,
               outputPath: `${isServer ? "../" : ""}static/chunks/fonts/`,
               name: '[name]-[hash].[ext]'


### PR DESCRIPTION
Third-party webpack configurations should *always* use `require.resolve` when referencing loader names, as they otherwise may load the wrong version of the loader depend how the package manager hoists the tree.