### PR TITLE
Add option for setting inline file size limit in `url-loader`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ module.exports = withFonts({
 });
 ```
 
+### inlineFontLimit
+Inlines fonts with sizes below inlineFontLimit to Base64. Default value is 8192.
+
+Example usage:
+
+```js
+// next.config.js
+const withFonts = require('next-fonts')
+module.exports = withFonts({
+  inlineFontLimit: 16384,
+  webpack(config, options) {
+    return config
+  }
+})
+```
+
 ## Examples repository
 
 Please see https://github.com/rohanray/next-fonts-example for usage with Nextjs v9.2+

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = (nextConfig = {}) => {
 
       const enableSvg = nextConfig.enableSvg || false;
 
+      const limit = nextConfig.inlineFontLimit || 8192;
+
       let testPattern = /\.(woff|woff2|eot|ttf|otf)$/;
 
       if (enableSvg) testPattern = /\.(woff|woff2|eot|ttf|otf|svg)$/;
@@ -27,7 +29,7 @@ module.exports = (nextConfig = {}) => {
           {
             loader: require.resolve('url-loader'),
             options: {
-              limit: 8192,
+              limit,
               fallback: require.resolve('file-loader'),
               publicPath: `${assetPrefix}/_next/static/chunks/fonts/`,
               outputPath: `${isServer ? "../" : ""}static/chunks/fonts/`,


### PR DESCRIPTION
This adds supporting for setting this `limit` property in `url-loader` by passing `inlineFontLimit` with a custom value.


---

Hello @rohanray! I created this PR to give the option for setting a custom limit in `url-loader`. Let me know what you think! Feel free to edit/modify as you see fit. This is based on how it is setup in next-images https://github.com/twopluszero/next-images#inlineimagelimit