### PR TITLE
Corrected stripped parameters for font version

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ module.exports = (nextConfig = {}) => {
 
       const limit = nextConfig.inlineFontLimit || 8192;
 
-      let testPattern = /\.(woff|woff2|eot|ttf|otf)$/;
+      let testPattern = /\.(woff(2)?|eot|ttf|otf)(\?v=\d+\.\d+\.\d+)$/;
 
-      if (enableSvg) testPattern = /\.(woff|woff2|eot|ttf|otf|svg)$/;
+      if (enableSvg) testPattern = /\.(woff(2)?|eot|ttf|otf|svg)(\?v=\d+\.\d+\.\d+)?$/;
 
       config.module.rules.push({
         test: testPattern,


### PR DESCRIPTION
Using this library to import fontawesome led me to some issue. next-fonts removes all the url parameters in my file path when I call url() in my css file.

I couldn't import fontawesome because of that. 

As you can see in this example repo : https://github.com/generalgmt/Andela/blob/master/font-awesome-4.1.0/css/font-awesome.css

We need to import the font using its version "../fonts/fontawesome-webfont.eot?v=4.1.0"

I edited next-fonts to keep "?v=X.X.X" in the newly created path.