### PR TITLE
Make the package compatible with webpack 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,10 +22,8 @@ module.exports = (nextConfig = {}) => {
 
       config.module.rules.push({
         test: testPattern,
-        issuer: {
-          // Next.js already handles url() in css/sass/scss files
-          test: /\.\w+(?<!(s?c|sa)ss)$/i,
-        },
+        // Next.js already handles url() in css/sass/scss files
+        issuer: /\.\w+(?<!(s?c|sa)ss)$/i,
         use: [
           {
             loader: require.resolve('url-loader'),


### PR DESCRIPTION
After adding `"webpack": "^5.4.0"` to `package.json` → `resolutions` in one of my Next.js projects [as advised](https://nextjs.org/blog/next-9-5#webpack-5-support-beta), I saw this error in the build output:

```txt
> Build error occurred
ValidationError: Invalid configuration object. Webpack has been initialized using a configuration object that does not match the API schema.
 - configuration[0].module.rules[3].issuer has an unknown property 'test'. These properties are valid:
   object { and?, not?, or? }
 - configuration[1].module.rules[3].issuer has an unknown property 'test'. These properties are valid:
   object { and?, not?, or? }
    at validate (/Users/ak/-/projects/emi-penza/website/node_modules/webpack/node_modules/schema-utils/dist/validate.js:104:11)
    at validateSchema (/Users/ak/-/projects/emi-penza/website/node_modules/webpack/lib/validateSchema.js:73:2)
    at create (/Users/ak/-/projects/emi-penza/website/node_modules/webpack/lib/webpack.js:102:3)
    at webpack (/Users/ak/-/projects/emi-penza/website/node_modules/webpack/lib/webpack.js:139:31)
```

The origin was `next-fonts` and the issue ended up being quite easily fixable. See `Rule.issuer` docs
- for webpack v4: https://v4.webpack.js.org/configuration/module/#ruleissuer
- for webpack v5: https://webpack.js.org/configuration/module/#ruleissuer

PS: I'm aware of #34 but I still find this package useful. It helps keep fonts next to a file with the global styles. I also don't have to worry about keeping too many files with all sorts of font-faces and using only a couple of them (only the ones mentioned in `url` will end up in the prod container). Finally, because of `name: [name]-[hash].[ext]`, I don't have to worry about cache invalidation myself.

It'd be great if you could release a patch and maintain the project in general. Thanks for your effort on creating it in the first place! 👍